### PR TITLE
chore: PR workflow for building dist

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,6 +5,8 @@ on:
 name: release-please
 jobs:
   build:
+    env:
+      ACTION_NAME: release-please-action
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -14,21 +16,55 @@ jobs:
       run: npm run build
     - name: commit
       run: |-
+        set -e
+        # get current commit hash
+        CURRENT_HASH=$(git rev-parse HEAD)
+        # get last commit hash of last build dist
+        LAST_BUILD_HASH=$(git log --author=google-github-actions-bot -1 --pretty=format:"%H")
+        DIFF=""
+        # build and commit dist if diff
         git config --global user.name "actions-bot"
+        git config user.email 'github-actions-bot@google.com'
         git add dist/
-        git diff-index --quiet HEAD || git commit -m "chore: build dist"
-        git pull --rebase
-        git push origin main
+        git diff-index --quiet HEAD || git commit -m "chore: build dist ${ACTION_NAME}"
+        # if last commit hash of last build dist was found, get logs of commits in btw for PR body
+        if [ -z "$LAST_BUILD_HASH" ]
+        then
+              echo "Unable to find last commit by bot, skipping diff gen"
+        else
+              DIFF=$(git log ${LAST_BUILD_HASH}...${CURRENT_HASH} --oneline)
+              echo $DIFF
+        fi
+        # set env vars
+        echo "CURRENT_HASH=${CURRENT_HASH}" >> $GITHUB_ENV
+        echo "LAST_BUILD_HASH=${LAST_BUILD_HASH}" >> $GITHUB_ENV
+        echo 'DIFF<<EOF' >> $GITHUB_ENV
+        echo "${DIFF}" >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+    - name: Create PR with dist
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+        commit-message: Build dist
+        author: "actions-bot <github-actions-bot@google.com>"
+        title: "chore: build dist"
+        body: |
+          Build dist PR
+          ${{env.DIFF}}
+        labels: automated pr
+        branch: create-pull-request/build-dist
+        delete-branch: true
+        push-to-fork: google-github-actions-bot/${{env.ACTION_NAME}}
   release-please-pr:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2.5.7
         with:
-          token: ${{ secrets.RELEASE_PR_TOKEN }}
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           release-type: node
           fork: true
-          package-name: release-please-action
+          package-name: ${{env.ACTION_NAME}}
           command: release-pr
   release-please-release:
     runs-on: ubuntu-latest
@@ -38,5 +74,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
-          package-name: release-please-action
+          package-name: ${{env.ACTION_NAME}}
           command: github-release


### PR DESCRIPTION
- Instead of commits to main, open a PR with dist from a fork
- Generate diff of commits in dist (if able to find previous bot commit) and add to body of PR
- Use `google-github-actions-bot` for both build PR and release PR
