### PR TITLE
feat: pass monorepoTags and packageName when creating GitHub release

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ async function main () {
       repoUrl: process.env.GITHUB_REPOSITORY,
       packageName,
       path,
-      token
+      monorepoTags,
+      packageName,
+      token,
     })
     const releaseCreated = await gr.createRelease()
     if (releaseCreated) {


### PR DESCRIPTION
This variables are now used when multiple packages are being released from the same repository.