### PR TITLE
fix(release-please): patch branch detection logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -150,11 +150,11 @@
       "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.3.1.tgz",
-      "integrity": "sha512-gKnD7zjja2Ne2YJniQhcmVFnJ4vkIVjBeMDQaV4fVJkLniZUmm8WZ2GRF7HkueI4kT0B6sfDK02TYwskRMG3dQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
+      "integrity": "sha512-+v5PcvrUcDeFXf8hv1gnNvNLdm4C0+2EiuWt9EatjjUmfriM1pTMM+r4j1lLHxeBQ9bVDmbywb11e3KjuavieA==",
       "requires": {
-        "@octokit/types": "^6.0.3",
+        "@octokit/types": "^6.1.0",
         "deprecation": "^2.3.1"
       }
     },
@@ -184,20 +184,20 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.11.tgz",
-      "integrity": "sha512-qOF1/9qsyuyKVGpOdcfE0XJXoKBM3x/j2cAMTGCVeeaR+nZZ60JY1fPTjadelDgKVwHFfghqeX/li+X1YYGENg==",
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.12.tgz",
+      "integrity": "sha512-hNRCZfKPpeaIjOVuNJzkEL6zacfZlBPV8vw8ReNeyUkVvbuCvvrrx8K8Gw2eyHHsmd4dPlAxIXIZ9oHhJfkJpw==",
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "4.3.1"
+        "@octokit/plugin-rest-endpoint-methods": "4.4.1"
       }
     },
     "@octokit/types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.0.tgz",
-      "integrity": "sha512-bMWBmg77MQTiRkOVyf50qK3QECWOEy43rLy/6fTWZ4HEwAhNfqzMcjiBDZAowkILwTrFvzE1CpP6gD0MuPHS+A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.1.tgz",
+      "integrity": "sha512-btm3D6S7VkRrgyYF31etUtVY/eQ1KzrNRqhFt25KSe2mKlXuLXJilglRC6eDA2P6ou94BUnk/Kz5MPEolXgoiw==",
       "requires": {
         "@octokit/openapi-types": "^2.0.0",
         "@types/node": ">= 8"
@@ -3089,9 +3089,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-8.0.0.tgz",
-      "integrity": "sha512-PS+ziIOQx/iYjRBLz4QPk53SOObbCWHs1cKH3qiRfWmHIOPfDoCAB9Mu/SthrDPSpKAKxBEl7vlOPTtIq01IWg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-8.0.1.tgz",
+      "integrity": "sha512-o6JiagjOpAyragZTiOMKH2MtGAT2O90IB/TohAgvDMcuUYviU+jFefn+wNsvxe/nH0YRSOETiOuc2G34ofFEzg==",
       "requires": {
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.3.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "release-please": "^8.0.0"
+    "release-please": "^8.0.1"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",


### PR DESCRIPTION
Ruby now uses `/` as a separator for version tags in monorepos, the same as go.