### PR TITLE
fix(go): filter additional PRs from gapic repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3089,9 +3089,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "8.0.2-candidte.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-8.0.2-candidte.0.tgz",
-      "integrity": "sha512-wI5oo2VH2AgK+lcg8Yk4wrgQgSb/rge7S9UcvjpBRlnAoGBCXqLiMQV42shW+2kN7cxAvAtCYXKNNTMujxTgNw==",
+      "version": "8.0.2-candidte.1",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-8.0.2-candidte.1.tgz",
+      "integrity": "sha512-ebOEuZGnqucbgxX1vxse2vweS8lQTQ2GN4IbUo7QoSPas5D6iEDAFyRHF0sKbslzhraRLQV1nkrocZxGEjQxSw==",
       "requires": {
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.3.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "release-please": "^8.0.2-candidte.0"
+    "release-please": "^8.0.2-candidte.1"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",


### PR DESCRIPTION
Our gapic repository does not include any commits in a release for a submodule, if they're not prefixed with the appropriate commit [type](https://www.conventionalcommits.org/en/v1.0.0/#summary).