### PR TITLE
feat: allow changelogPath to be specified

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,15 +26,18 @@ inputs:
   monorepo-tags:
     description: 'add prefix to tags and branches, allowing multiple libraries to be released from the same repository'
     required: false
+  changelog-path:
+    description: 'specify a CHANGELOG path other than the root CHANGELOG.md'
+    required: false
   changelog-types:
     description: 'changlelog commit types'
-    require: false
+    required: false
   command:
     description: 'release-please command to run, either "github-release", or "release-pr" (defaults to running both)'
-    require: false
+    required: false
   version-file:
     description: 'provide a path to a version file to increment (used by ruby releaser)'
-    require: false
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ const RELEASE_LABEL = 'autorelease: pending'
 
 async function main () {
   const bumpMinorPreMajor = Boolean(core.getInput('bump-minor-pre-major'))
-  // TODO(bcoe): remove this log line.
   const monorepoTags = Boolean(core.getInput('monorepo-tags'))
   const packageName = core.getInput('package-name')
   const path = core.getInput('path') ? core.getInput('path') : undefined
   const releaseType = core.getInput('release-type')
   const token = core.getInput('token')
   const fork = core.getInput('fork') ? true : undefined
+  const changelogPath = core.getInput('changelog-path') ? core.getInput('changelog-path') : undefined
   const changelogTypes = core.getInput('changelog-types')
   const command = core.getInput('command') ? core.getInput('command') : undefined
   const versionFile = core.getInput('version-file') ? core.getInput('version-file') : undefined
@@ -33,7 +33,8 @@ async function main () {
       packageName,
       path,
       monorepoTags,
-      token
+      token,
+      changelogPath
     })
     const releaseCreated = await gr.createRelease()
     if (releaseCreated) {


### PR DESCRIPTION
Allow `changelogPath` to be configured.

See: https://github.com/googleapis/google-cloud-go/pull/3441