### PR TITLE
fix(release-please): map go to alternate tag separator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -271,9 +271,9 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
     },
     "@types/node": {
-      "version": "14.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
+      "version": "14.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.11.tgz",
+      "integrity": "sha512-BJ97wAUuU3NUiUCp44xzUFquQEvnk1wu7q4CMEUYKJWjdkr0YWYDsm4RFtAvxYsNjLsKcrFt6RvK8r+mnzMbEQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3089,9 +3089,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "8.0.2-candidate.4",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-8.0.2-candidate.4.tgz",
-      "integrity": "sha512-jpATr8boMLawgqpNXyqOoICjep5nOxANGLsRYcPLbkdCDAszL184Zym8nmtTtlz4HKHCahLcjYV7Pa4pVmpmyQ==",
+      "version": "8.0.2-candidate.6",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-8.0.2-candidate.6.tgz",
+      "integrity": "sha512-bX/kSyQF1JPmFoKsPhCtcoVV6pTmg9/otnBkBhxVKR9E7JMK12xGu8E3IN7OoiSUpkTyvEEVbcJtQtWp1qowDw==",
       "requires": {
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.3.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "release-please": "^8.0.2-candidate.4"
+    "release-please": "^8.0.2-candidate.6"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",


### PR DESCRIPTION
The alternate tag separator was not properly being looked up for go.