### PR TITLE
fix(go): pass release-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ async function main () {
       path,
       monorepoTags,
       token,
-      changelogPath
+      changelogPath,
+      releaseType
     })
     const releaseCreated = await gr.createRelease()
     if (releaseCreated) {


### PR DESCRIPTION
We need to pass the release-type to the class that tags.