### PR TITLE
feat(manifest): add manifest-pr command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Automate releases with Conventional Commit Messages.
 | `changelog-types` | A JSON formatted String containing to override the outputted changelog sections |
 | `version-file` | provide a path to a version file to increment (used by ruby releaser) |
 | `fork`          | Should the PR be created from a fork. Default `false`|
-| `command`          | release-please command to run, either `github-release`, or `release-pr` (_defaults to running both_) |
+| `command`          | release-please command to run, either `github-release`, or `release-pr`, `manifest`, `manifest-pr` (_defaults to running both_) |
 | `default-branch`  | branch to open pull release PR against (detected by default) |
 | `pull-request-title-pattern`  | title pattern used to make release PR, defaults to using `chore${scope}: release${component} ${version}`. |
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { factory } = require('release-please/build/src')
 
 const CONFIG_FILE = 'release-please-config.json'
 const MANIFEST_FILE = '.release-please-manifest.json'
-const MANIFEST_COMMAND = 'manifest'
+const MANIFEST_COMMANDS = ['manifest', 'manifest-pr']
 const RELEASE_LABEL = 'autorelease: pending'
 const GITHUB_RELEASE_COMMAND = 'github-release'
 const GITHUB_RELEASE_PR_COMMAND = 'release-pr'
@@ -34,13 +34,14 @@ function getManifestInput () {
   }
 }
 
-async function runManifest () {
+async function runManifest (command) {
   const githubOpts = getGitHubInput()
   const manifestOpts = { ...githubOpts, ...getManifestInput() }
   const pr = await factory.runCommand('manifest-pr', manifestOpts)
   if (pr) {
     core.setOutput('pr', pr)
   }
+  if (command === 'manifest-pr') return
 
   const releasesCreated = await factory.runCommand('manifest-release', manifestOpts)
   if (releasesCreated) {
@@ -58,8 +59,8 @@ async function runManifest () {
 
 async function main () {
   const command = core.getInput('command') || undefined
-  if (command === MANIFEST_COMMAND) {
-    return await runManifest()
+  if (MANIFEST_COMMANDS.includes(command)) {
+    return await runManifest(command)
   }
 
   const { token, fork, defaultBranch, apiUrl, repoUrl } = getGitHubInput()

--- a/test/release-please.js
+++ b/test/release-please.js
@@ -361,4 +361,18 @@ describe('release-please-action', () => {
       pr: 25
     })
   })
+
+  it('opens PR only for manifest-pr', async () => {
+    input = { command: 'manifest-pr' }
+
+    const runCommandStub = sandbox.stub(factory, 'runCommand')
+    const manifestReleasePRStub = runCommandStub.withArgs('manifest-pr').returns(25)
+
+    await action.main()
+
+    sinon.assert.calledOnce(manifestReleasePRStub)
+    assert.deepStrictEqual(output, {
+      pr: 25
+    })
+  })
 })


### PR DESCRIPTION
Adds `manifest-pr` command for running PR creation step in isolation.

Refs: https://github.com/googleapis/google-api-nodejs-client/pull/2557
CC: @joeldodge79 