### PR TITLE
feat: add release_created per path in manifest PR

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,13 +45,16 @@ async function runManifest (command) {
 
   const releasesCreated = await factory.runCommand('manifest-release', manifestOpts)
   if (releasesCreated) {
-    core.setOutput('release_created', true)
     core.setOutput('releases_created', true)
     for (const [path, release] of Object.entries(releasesCreated)) {
       if (!release) {
         continue
       }
-      core.setOutput(`${path}--release_created`, true)
+      if (path === '.') {
+        core.setOutput('release_created', true)
+      } else {
+        core.setOutput(`${path}--release_created`, true)
+      }
       for (const [key, val] of Object.entries(release)) {
         if (path === '.') {
           core.setOutput(key, val)

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function runManifest (command) {
       if (!release) {
         continue
       }
-      core.setOuput(`${path}--release_created`, true)
+      core.setOutput(`${path}--release_created`, true)
       for (const [key, val] of Object.entries(release)) {
         core.setOutput(`${path}--${key}`, val)
       }

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ async function runManifest (command) {
       if (!release) {
         continue
       }
+      core.setOuput(`${path}--release_created`, true)
       for (const [key, val] of Object.entries(release)) {
         core.setOutput(`${path}--${key}`, val)
       }

--- a/test/release-please.js
+++ b/test/release-please.js
@@ -363,6 +363,7 @@ describe('release-please-action', () => {
       release_created: true,
       'path/pkgA--upload_url': 'http://example.com',
       'path/pkgA--tag_name': 'v1.0.0',
+      'path/pkgA--release_created': true,
       tag_name: 'v1.0.0',
       upload_url: 'http://example.com',
       pr: 25


### PR DESCRIPTION
We were just implementing a release process on a vscode extension in our monorepo, and that has a separate release flow than anything else, so we'd only want the publish phase to run if a specific path was released.

This adds a `release_created` flag on each published package in a manifest release.