### PR TITLE
docs: add 'go' to release types list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Release Please automates releases for the following flavors of repositories:
 | ocaml             | [An OCaml repository, containing 1 or more opam or esy files and a CHANGELOG.md](https://github.com/grain-lang/binaryen.ml) |
 | `simple` | [A repository with a version.txt and a CHANGELOG.md](https://github.com/googleapis/gapic-generator) |
 | helm | A helm chart repository with a Chart.yaml and a CHANGELOG.md |
+| go | A go repository with a CHANGELOG.md |
 
 
 ## How release please works


### PR DESCRIPTION
https://github.com/googleapis/release-please/pull/890

I noticed a recent pull request that adds a generic go release type and have updated the README to reflect the same.
Please let me know if I have missed anything 🙇🏼 