### PR TITLE
fix(manifest): if "." is used it should have same outputs non-mono-repo release strategy

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,13 +45,18 @@ async function runManifest (command) {
 
   const releasesCreated = await factory.runCommand('manifest-release', manifestOpts)
   if (releasesCreated) {
+    core.setOutput('release_created', true)
     core.setOutput('releases_created', true)
     for (const [path, release] of Object.entries(releasesCreated)) {
       if (!release) {
         continue
       }
       for (const [key, val] of Object.entries(release)) {
-        core.setOutput(`${path}--${key}`, val)
+        if (path === '.') {
+          core.setOutput(key, val)
+        } else {
+          core.setOutput(`${path}--${key}`, val)
+        }
       }
     }
   }

--- a/test/release-please.js
+++ b/test/release-please.js
@@ -345,6 +345,10 @@ describe('release-please-action', () => {
         {
           upload_url: 'http://example.com',
           tag_name: 'v1.0.0'
+        },
+        '.': {
+          upload_url: 'http://example.com',
+          tag_name: 'v1.0.0'
         }
       })
 
@@ -356,8 +360,11 @@ describe('release-please-action', () => {
     sinon.assert.calledOnce(manifestReleasePRStub)
     assert.deepStrictEqual(output, {
       releases_created: true,
+      release_created: true,
       'path/pkgA--upload_url': 'http://example.com',
       'path/pkgA--tag_name': 'v1.0.0',
+      tag_name: 'v1.0.0',
+      upload_url: 'http://example.com',
       pr: 25
     })
   })


### PR DESCRIPTION
If the special "." syntax is used for a manifest releaser (which represents a release in the root folder of a library) it should set the same outputs as a non-manifest releaser.