### PR TITLE
feat: output list of paths released during manifest release

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,12 +44,14 @@ async function runManifest (command) {
   if (command === 'manifest-pr') return
 
   const releasesCreated = await factory.runCommand('manifest-release', manifestOpts)
+  const pathsReleased = []
   if (releasesCreated) {
     core.setOutput('releases_created', true)
     for (const [path, release] of Object.entries(releasesCreated)) {
       if (!release) {
         continue
       }
+      pathsReleased.push(path)
       if (path === '.') {
         core.setOutput('release_created', true)
       } else {
@@ -64,6 +66,9 @@ async function runManifest (command) {
       }
     }
   }
+  // Paths of all releases that were created, so that they can be passed
+  // to matrix in next step:
+  core.setOutput('paths_released', JSON.stringify(pathsReleased))
 }
 
 async function main () {

--- a/test/release-please.js
+++ b/test/release-please.js
@@ -366,7 +366,8 @@ describe('release-please-action', () => {
       'path/pkgA--release_created': true,
       tag_name: 'v1.0.0',
       upload_url: 'http://example.com',
-      pr: 25
+      pr: 25,
+      paths_released: '["path/pkgA","."]'
     })
   })
 


### PR DESCRIPTION
Output a list of paths that releases were created for, so that it can be used in GitHub action matrix.