### PR TITLE
feat: add `bump-patch-for-minor-pre-major` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Automate releases with Conventional Commit Messages.
 | `release-type` | What type of project is this a release for? Reference [Release types supported](#release-types-supported); new types of releases can be [added here](https://github.com/googleapis/release-please/tree/master/src/releasers) |
 | `package-name` | A name for the artifact releases are being created for (this might be the `name` field in a `setup.py` or `package.json`) |
 | `bump-minor-pre-major` | Should breaking changes before 1.0.0 produce minor bumps?  Default `No` |
+| `bump-patch-for-minor-pre-major` | Should feat changes before 1.0.0 produce patch bumps instead of minor bumps?  Default `No` |
 | `path`          | create a release from a path other than the repository's root |
 | `monorepo-tags` | add prefix to tags and branches, allowing multiple libraries to be released from the same repository. |
 | `changelog-types` | A JSON formatted String containing to override the outputted changelog sections |

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'should breaking changes before 1.0.0 produce minor bumps'
     required: false
     default: false
+  bump-patch-for-minor-pre-major:
+    description: 'should feat changes before 1.0.0 produce patch bumps instead of minor bumps'
+    required: false
+    default: false
   path:
     description: "create a release from a path other than the repository's root"
     required: false

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ async function main () {
   const { token, fork, defaultBranch, apiUrl, repoUrl } = getGitHubInput()
 
   const bumpMinorPreMajor = getBooleanInput('bump-minor-pre-major')
+  const bumpPatchForMinorPreMajor = getBooleanInput('bump-patch-for-minor-pre-major')
   const monorepoTags = getBooleanInput('monorepo-tags')
   const packageName = core.getInput('package-name')
   const path = core.getInput('path') || undefined
@@ -128,6 +129,7 @@ async function main () {
       token,
       label: RELEASE_LABEL,
       bumpMinorPreMajor,
+      bumpPatchForMinorPreMajor,
       changelogPath,
       changelogSections,
       versionFile,

--- a/package-lock.json
+++ b/package-lock.json
@@ -274,16 +274,16 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
-      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.2.2.tgz",
+      "integrity": "sha512-EVcXQ+ZrC04cg17AMg1ofocWMxHDn17cB66ZHgYc0eUwjFtxS0oBzkyw2VqIrHBwVgtfoYrq1WMQfQmMjUwthw=="
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.0.tgz",
-      "integrity": "sha512-8YYzALPMvEZ35kgy5pdYvQ22Roz+BIuEaedO575GwE2vb/ACDqQn0xQrTJR4tnZCJn7pi8+AWPVjrFDaERIyXQ==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.3.tgz",
+      "integrity": "sha512-kdc65UEsqze/9fCISq6BxLzeB9qf0vKvKojIfzgwf4tEF+Wy6c9dXnPFE6vgpoDFB1Z5Jek5WFVU6vL1w22+Iw==",
       "requires": {
-        "@octokit/types": "^6.26.0"
+        "@octokit/types": "^6.28.1"
       }
     },
     "@octokit/plugin-request-log": {
@@ -292,11 +292,11 @@
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.10.0.tgz",
-      "integrity": "sha512-HiUZliq5wNg15cevJlTo9zDnPXAD0BMRhLxbRNPnq9J3HELKesDTOiou56ax2jC/rECUkK/uJTugrizYKSo/jg==",
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.10.4.tgz",
+      "integrity": "sha512-Dh+EAMCYR9RUHwQChH94Skl0lM8Fh99auT8ggck/xTzjJrwVzvsd0YH68oRPqp/HxICzmUjLfaQ9sy1o1sfIiA==",
       "requires": {
-        "@octokit/types": "^6.27.0",
+        "@octokit/types": "^6.28.1",
         "deprecation": "^2.3.1"
       }
     },
@@ -335,11 +335,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
-      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.28.1.tgz",
+      "integrity": "sha512-XlxDoQLFO5JnFZgKVQTYTvXRsQFfr/GwDUU108NJ9R5yFPkA2qXhTJjYuul3vE4eLXP40FA2nysOu2zd6boE+w==",
       "requires": {
-        "@octokit/openapi-types": "^10.1.0"
+        "@octokit/openapi-types": "^10.2.2"
       }
     },
     "@sinonjs/commons": {
@@ -805,9 +805,9 @@
       "dev": true
     },
     "conventional-changelog-conventionalcommits": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz",
-      "integrity": "sha512-sj9tj3z5cnHaSJCYObA9nISf7eq/YjscLPoq6nmew4SiOjxqL2KRpK20fjnjVbpNDjJ2HR3MoVcWKXwbVvzS0A==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
+      "integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
       "requires": {
         "compare-func": "^2.0.0",
         "lodash": "^4.17.15",
@@ -3218,9 +3218,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "11.23.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-11.23.0.tgz",
-      "integrity": "sha512-LKP25W1wNjntvuJtaatxfvF34T7lNDbfu5p5tLtwqmhcj0qSNoL5gsmPCA+C8d7n2ETilPXjgbikIUg/gxDy5g==",
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-11.24.2.tgz",
+      "integrity": "sha512-lobR4bBmN8dG39TAxvVOORbQZuShy9LAoqthgdUMLDAnPXqFdfxVbNtIgGZB4wza0TEkPshr71RD83Li9fv5sg==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "release-please": "^11.23.0"
+    "release-please": "^11.24.2"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.27.0",

--- a/test/release-please.js
+++ b/test/release-please.js
@@ -11,6 +11,7 @@ const defaultInput = {
   fork: 'false',
   clean: 'true',
   'bump-minor-pre-major': 'false',
+  'bump-patch-for-minor-pre-major': 'false',
   path: '',
   'monorepo-tags': 'false',
   'changelog-path': '',


### PR DESCRIPTION
Pass `bump-patch-for-minor-pre-major` to release-please to allow bumping
patch versions instead of minors for feat changes. Disabled by default. Change is backwards compatible.

This functionality was broken in release-please until now: https://github.com/googleapis/release-please/issues/1049
I suppose the fix should be in the new release of release-please soon.

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>