### PR TITLE
feat: support pythonpackage/__init__.py without pyproject.toml support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3218,7 +3218,7 @@
       "dev": true
     },
     "release-please": {
-      "version": "11.24.1",
+      "version": "11.24.2",
       "resolved": "https://registry.npmjs.org/release-please/-/release-please-11.24.1.tgz",
       "integrity": "sha512-A2S2PTnqewegV46ccNSReEr1KsZgwGaejqVxQ7NFLoY314YZUqoUd8SQQfFmDkqC7KFxDGTNUEVMDCX7UGOovw==",
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3218,9 +3218,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "11.23.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-11.23.0.tgz",
-      "integrity": "sha512-LKP25W1wNjntvuJtaatxfvF34T7lNDbfu5p5tLtwqmhcj0qSNoL5gsmPCA+C8d7n2ETilPXjgbikIUg/gxDy5g==",
+      "version": "11.24.1",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-11.24.1.tgz",
+      "integrity": "sha512-A2S2PTnqewegV46ccNSReEr1KsZgwGaejqVxQ7NFLoY314YZUqoUd8SQQfFmDkqC7KFxDGTNUEVMDCX7UGOovw==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "release-please": "^11.23.0"
+    "release-please": "^11.24.1"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.27.0",


### PR DESCRIPTION
This is in release-please v11.24.0. Bump to .1 while at it.

Refs https://github.com/googleapis/release-please/pull/1026