### PR TITLE
feat(input): add github API URL configuration for input

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Automate releases with Conventional Commit Messages.
 | `default-branch`  | branch to open pull release PR against (detected by default) |
 | `pull-request-title-pattern`  | title pattern used to make release PR, defaults to using `chore${scope}: release${component} ${version}`. |
 | `changelog-path` | configure alternate path for `CHANGELOG.md`. Default `CHANGELOG.md` |
+| `github-api-url` | configure github API URL. Default `https://api.github.com` |
 
 | output | description |
 |:---:|---|

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const MANIFEST_COMMANDS = ['manifest', 'manifest-pr']
 const RELEASE_LABEL = 'autorelease: pending'
 const GITHUB_RELEASE_COMMAND = 'github-release'
 const GITHUB_RELEASE_PR_COMMAND = 'release-pr'
+const GITHUB_API_URL = 'https://api.github.com'
 
 function getBooleanInput (input) {
   const trueValue = ['true', 'True', 'TRUE', 'yes', 'Yes', 'YES', 'y', 'Y', 'on', 'On', 'ON']
@@ -22,7 +23,7 @@ function getGitHubInput () {
     fork: getBooleanInput('fork'),
     defaultBranch: core.getInput('default-branch') || undefined,
     repoUrl: process.env.GITHUB_REPOSITORY,
-    apiUrl: 'https://api.github.com',
+    apiUrl: core.getInput('github-api-url') || GITHUB_API_URL,
     token: core.getInput('token', { required: true })
   }
 }


### PR DESCRIPTION
Hi everyone,
I want to use this action on Github enterprise, but this action default use Github API URL.
If users use Github enterprise, they need to be changed Github API URL.
this PR that add Github API URL input for this feature.

I hope to help this project to be better, thanks.