### PR TITLE
fix(config): add apiUrl config on Github release command

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,8 @@ async function main () {
       changelogPath,
       releaseType,
       defaultBranch,
-      pullRequestTitlePattern
+      pullRequestTitlePattern,
+      apiUrl
     })
 
     if (releaseCreated) {


### PR DESCRIPTION
Hi everyone,
this action's first step didn't use apiUrl input, 
if user change apiUrl input then this action always use `https://api.github.com` endpoint, so this PR fix this case.

I hope to help this project to be better, thanks.