### PR TITLE
Feat/add repo url for input

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Automate releases with Conventional Commit Messages.
 | `changelog-path` | configure alternate path for `CHANGELOG.md`. Default `CHANGELOG.md` |
 | `github-api-url` | configure github API URL. Default `https://api.github.com` |
 | `--signoff` | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line at the end of the commit log message using the user and email provided. (format "Name \<email@example.com\>") |
+| `repo-url` | configure github repository URL. Default `process.env.GITHUB_REPOSITORY` |
 
 | output | description |
 |:---:|---|

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,10 @@ inputs:
     description: 'configure github API URL. Default `https://api.github.com`'
     required: false
     default: ''
+  repo-url:
+    description: 'configure github repository URL. Default `process.env.GITHUB_REPOSITORY`'
+    required: false
+    default: ''
 
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ async function main () {
   if (!command || command === GITHUB_RELEASE_COMMAND) {
     const releaseCreated = await factory.runCommand(GITHUB_RELEASE_COMMAND, {
       label: RELEASE_LABEL,
-      repoUrl: process.env.GITHUB_REPOSITORY,
+      repoUrl,
       packageName,
       path,
       monorepoTags,

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function getGitHubInput () {
   return {
     fork: getBooleanInput('fork'),
     defaultBranch: core.getInput('default-branch') || undefined,
-    repoUrl: process.env.GITHUB_REPOSITORY,
+    repoUrl: core.getInput('repo-url') || process.env.GITHUB_REPOSITORY,
     apiUrl: core.getInput('github-api-url') || GITHUB_API_URL,
     token: core.getInput('token', { required: true })
   }


### PR DESCRIPTION
Hi everyone,
I found two way (process.env & getGitHubInput func) to get repo Url on code,
So I changed this different ways and always use getGitHubInput func to get input metadata.

And I add new input  repo-url option for config. 

I hope to help this project to be better, thanks.