### PR TITLE
feat(input): add github GraphQL URL configuration for input

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Automate releases with Conventional Commit Messages.
 | `github-api-url` | configure github API URL. Default `https://api.github.com` |
 | `--signoff` | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line at the end of the commit log message using the user and email provided. (format "Name \<email@example.com\>") |
 | `repo-url` | configure github repository URL. Default `process.env.GITHUB_REPOSITORY` |
+| `github-graphql-url` | configure github GraphQL URL. Default `https://api.github.com` |
 
 | output | description |
 |:---:|---|

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,10 @@ inputs:
     description: 'configure github API URL. Default `https://api.github.com`'
     required: false
     default: ''
+  github-graphql-url:
+    description: 'configure github GraphQL URL. Default `https://api.github.com`'
+    required: false
+    default: ''
   repo-url:
     description: 'configure github repository URL. Default `process.env.GITHUB_REPOSITORY`'
     required: false

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const RELEASE_LABEL = 'autorelease: pending'
 const GITHUB_RELEASE_COMMAND = 'github-release'
 const GITHUB_RELEASE_PR_COMMAND = 'release-pr'
 const GITHUB_API_URL = 'https://api.github.com'
+const GITHUB_GRAPHQL_URL = 'https://api.github.com'
 
 const signoff = core.getInput('signoff') || undefined
 
@@ -26,6 +27,7 @@ function getGitHubInput () {
     defaultBranch: core.getInput('default-branch') || undefined,
     repoUrl: core.getInput('repo-url') || process.env.GITHUB_REPOSITORY,
     apiUrl: core.getInput('github-api-url') || GITHUB_API_URL,
+    graphqlUrl: core.getInput('github-graphql-url') || GITHUB_GRAPHQL_URL,
     token: core.getInput('token', { required: true })
   }
 }
@@ -81,7 +83,7 @@ async function main () {
     return await runManifest(command)
   }
 
-  const { token, fork, defaultBranch, apiUrl, repoUrl } = getGitHubInput()
+  const { token, fork, defaultBranch, apiUrl, graphqlUrl, repoUrl } = getGitHubInput()
 
   const bumpMinorPreMajor = getBooleanInput('bump-minor-pre-major')
   const bumpPatchForMinorPreMajor = getBooleanInput('bump-patch-for-minor-pre-major')
@@ -109,7 +111,8 @@ async function main () {
       releaseType,
       defaultBranch,
       pullRequestTitlePattern,
-      apiUrl
+      apiUrl,
+      graphqlUrl
     })
 
     if (releaseCreated) {
@@ -129,6 +132,7 @@ async function main () {
       packageName,
       path,
       apiUrl,
+      graphqlUrl,
       repoUrl,
       fork,
       token,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "release-please": "^12.5.0"
+    "release-please": "^12.6.0"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.27.0",


### PR DESCRIPTION
Hi everyone,
I want to use this action on Github enterprise, 
but I find root cause that use different GraphQL URL between Github and Github enterprise
I upgrade release-please package version from 12.5.0 to 12.6.0,
we can change GraphQL URL on this release 12.6.0,
so I add input on GitHub GraphQL URL configuration

I hope to help this project to be better, thanks.