### PR TITLE
feat(input): allow draft github release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Automate releases with Conventional Commit Messages.
 | `changelog-types` | A JSON formatted String containing to override the outputted changelog sections |
 | `version-file` | provide a path to a version file to increment (used by ruby releaser) |
 | `fork`          | Should the PR be created from a fork. Default `false`|
+| `draft` | Should the GitHub release be a draft. Default `false`|
 | `command`          | release-please command to run, either `github-release`, or `release-pr`, `manifest`, `manifest-pr` (_defaults to running both_) |
 | `default-branch`  | branch to open pull release PR against (detected by default) |
 | `pull-request-title-pattern`  | title pattern used to make release PR, defaults to using `chore${scope}: release${component} ${version}`. |
@@ -76,6 +77,7 @@ Automate releases with Conventional Commit Messages.
 | `patch` | Number representing patch semver value |
 | `sha` | sha that a GitHub release was tagged at |
 | `pr` | The PR number of an opened release (undefined if no release created) |
+| `draft` | `true` if the GitHub release is a draft, `false` otherwise |
 
 ### Release types supported
 

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,10 @@ inputs:
     description: 'configure github repository URL. Default `process.env.GITHUB_REPOSITORY`'
     required: false
     default: ''
+  draft:
+    description: 'should the GitHub release be a draft'
+    required: false
+    default: false
 
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ async function main () {
   const bumpMinorPreMajor = getBooleanInput('bump-minor-pre-major')
   const bumpPatchForMinorPreMajor = getBooleanInput('bump-patch-for-minor-pre-major')
   const monorepoTags = getBooleanInput('monorepo-tags')
+  const draft = getBooleanInput('draft')
   const packageName = core.getInput('package-name')
   const path = core.getInput('path') || undefined
   const releaseType = core.getInput('release-type', { required: true })
@@ -112,7 +113,8 @@ async function main () {
       defaultBranch,
       pullRequestTitlePattern,
       apiUrl,
-      graphqlUrl
+      graphqlUrl,
+      draft
     })
 
     if (releaseCreated) {

--- a/test/release-please.js
+++ b/test/release-please.js
@@ -20,7 +20,8 @@ const defaultInput = {
   'version-file': '',
   'default-branch': '',
   // eslint-disable-next-line no-template-curly-in-string
-  'pull-request-title-pattern': 'chore${scope}: release${component} ${version}'
+  'pull-request-title-pattern': 'chore${scope}: release${component} ${version}',
+  draft: 'false'
 }
 
 let input
@@ -254,7 +255,8 @@ describe('release-please-action', () => {
       patch: 3,
       version: 'v1.2.3',
       sha: 'abc123',
-      pr: 33
+      pr: 33,
+      draft: false
     }
     input = {
       'release-type': 'node',


### PR DESCRIPTION
Hi guys, 

I really love release-please-action, but it's missing an essential option for me. I'd like to release draft for non-manifest commands as well.

This PR would ammend that and allow the user to create GitHub release as drafts.

Please review. Thanks