### PR TITLE
feat: support extra-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Automate releases with Conventional Commit Messages.
 | `--signoff` | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line at the end of the commit log message using the user and email provided. (format "Name \<email@example.com\>") |
 | `repo-url` | configure github repository URL. Default `process.env.GITHUB_REPOSITORY` |
 | `github-graphql-url` | configure github GraphQL URL. Default `https://api.github.com` |
+| `extra-files` | Multiline input to claim extra files to bump. |
 
 | output | description |
 |:---:|---|

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,10 @@ inputs:
     description: 'configure github repository URL. Default `process.env.GITHUB_REPOSITORY`'
     required: false
     default: ''
+  extra-files:
+    description: 'extra files to bump'
+    required: false
+    default: []
 
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ inputs:
   extra-files:
     description: 'extra files to bump'
     required: false
-    default: []
+    default: ''
 
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ async function main () {
   const changelogSections = changelogTypes && JSON.parse(changelogTypes)
   const versionFile = core.getInput('version-file') || undefined
   const pullRequestTitlePattern = core.getInput('pull-request-title-pattern') || undefined
+  const extraFiles = core.getMultilineInput('extra-files')
 
   // First we check for any merged release PRs (PRs merged with the label
   // "autorelease: pending"):
@@ -144,7 +145,8 @@ async function main () {
       versionFile,
       defaultBranch,
       pullRequestTitlePattern,
-      signoff
+      signoff,
+      extraFiles
     })
 
     if (pr) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.6.0",
     "release-please": "^12.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
Purpose:
- add new action input: **extra-files**

Detail
- bump **@action/core** to latest(1.6.0) in order to use core.getMultilineInput
- add new action input: **extra-files**.
- **extra-files** is parsed by **@action.core.getMultilineInput**  and passed to release-please command factory

action example

```yaml

   
on:
  push:
    branches:
      - main
name: release-please
jobs:
  release-please:
    runs-on: ubuntu-latest
    steps:
      - uses: goatwu1993/release-please-action@34d9e9e3af8527cd341451fe508bab081659f3e3
        with:
          release-type: simple
          token: ${{ secrets.GITHUB_TOKEN }}
          extra-files:  |
            README.md
```