### PR TITLE
docs(readme): Update defaults format to use booleans (`true`/`false`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Automate releases with Conventional Commit Messages.
 | `token` | A GitHub secret token, the action defaults to using the special `secrets.GITHUB_TOKEN` |
 | `release-type` | What type of project is this a release for? Reference [Release types supported](#release-types-supported); new types of releases can be [added here](https://github.com/googleapis/release-please/tree/master/src/releasers) |
 | `package-name` | A name for the artifact releases are being created for (this might be the `name` field in a `setup.py` or `package.json`) |
-| `bump-minor-pre-major` | Should breaking changes before 1.0.0 produce minor bumps?  Default `No` |
-| `bump-patch-for-minor-pre-major` | Should feat changes before 1.0.0 produce patch bumps instead of minor bumps?  Default `No` |
+| `bump-minor-pre-major` | Should breaking changes before 1.0.0 produce minor bumps?  Default `false` |
+| `bump-patch-for-minor-pre-major` | Should feat changes before 1.0.0 produce patch bumps instead of minor bumps?  Default `false` |
 | `path`          | create a release from a path other than the repository's root |
 | `monorepo-tags` | add prefix to tags and branches, allowing multiple libraries to be released from the same repository. |
 | `changelog-types` | A JSON formatted String containing to override the outputted changelog sections |


### PR DESCRIPTION
Since #398 the input booleans no longer accept `Yes` or `No`, but only `true` or `false`.

Some defaults mentionned in the readme are using the old format (Example: "default: `No`"), which is now outdated and misleading.

This PR updates the readme to use only boolean notation (`true`/`false`) when describing defaults.