### PR TITLE
fix(release-please): Fix include-component-in-tag ignored in manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.6.0",
-        "release-please": "^13.4.2"
+        "release-please": "^13.4.8"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.27.0",
@@ -4350,9 +4350,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.4.2.tgz",
-      "integrity": "sha512-FBnfsLW2H46BP88IkpHYe1iedGwB3KtH+v/c7IM3xXNvQDzbIhyE1Dy3MxHrPlz07cOq+xdlWKl+50/nwN25+g==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.4.8.tgz",
+      "integrity": "sha512-sZ8cptHy/vPKZM31Cz1ua//srzOlTeEQbi0E/BWN4ZLmN81Znjm4PZAWmzHV1Cy/IE9uUnNFtrKx1epTd0tdOw==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",
@@ -8910,9 +8910,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.4.2.tgz",
-      "integrity": "sha512-FBnfsLW2H46BP88IkpHYe1iedGwB3KtH+v/c7IM3xXNvQDzbIhyE1Dy3MxHrPlz07cOq+xdlWKl+50/nwN25+g==",
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.4.8.tgz",
+      "integrity": "sha512-sZ8cptHy/vPKZM31Cz1ua//srzOlTeEQbi0E/BWN4ZLmN81Znjm4PZAWmzHV1Cy/IE9uUnNFtrKx1epTd0tdOw==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
     "@actions/core": "^1.6.0",
-    "release-please": "^13.4.2"
+    "release-please": "^13.4.8"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.27.0",


### PR DESCRIPTION
release-please v13.4.8 fixes an issue where include-component-in-tag is ignored in manifests.  This updates the dependency so that this action can benefit from the fix, as well.

Without this, https://github.com/google/shaka-player can't deploy release-please-action.