### PR TITLE
feat(deps): update release-please to 13.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Release Please automates releases for the following flavors of repositories:
 | `elixir` | An elixir repository with a mix.exs and a CHANGELOG.md |
 | `go` | Go repository, with a CHANGELOG.md |
 | `helm` | A helm chart repository with a Chart.yaml and a CHANGELOG.md |
+| `java` | [A strategy that generates SNAPSHOT version after each release](https://github.com/googleapis/release-please/blob/main/docs/java.md) |
+| `maven` | [Strategy for Maven projects, generates SNAPSHOT version after each release and updates `pom.xml` automatically](https://github.com/googleapis/release-please/blob/main/docs/java.md) |
 | `node` | [A Node.js repository, with a package.json and CHANGELOG.md](https://github.com/yargs/yargs) |
 | `ocaml` | [An OCaml repository, containing 1 or more opam or esy files and a CHANGELOG.md](https://github.com/grain-lang/binaryen.ml) |
 | `python` | [A Python repository, with a setup.py, setup.cfg, version.py and CHANGELOG.md](https://github.com/googleapis/python-storage) and optionally a pyproject.toml and a &lt;project&gt;/\_\_init\_\_.py |

--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ Release Please automates releases for the following flavors of repositories:
 
 | release type | description |
 |:---:|---|
+| `elixir` | An elixir repository with a mix.exs and a CHANGELOG.md |
+| `go` | Go repository, with a CHANGELOG.md |
+| `helm` | A helm chart repository with a Chart.yaml and a CHANGELOG.md |
 | `node` | [A Node.js repository, with a package.json and CHANGELOG.md](https://github.com/yargs/yargs) |
+| `ocaml` | [An OCaml repository, containing 1 or more opam or esy files and a CHANGELOG.md](https://github.com/grain-lang/binaryen.ml) |
 | `python` | [A Python repository, with a setup.py, setup.cfg, version.py and CHANGELOG.md](https://github.com/googleapis/python-storage) and optionally a pyproject.toml and a &lt;project&gt;/\_\_init\_\_.py |
 | `php` | [A php composer package with composer.json and CHANGELOG.md](https://github.com/setnemo/asterisk-notation)
 | `ruby` | [A Ruby repository, with version.rb and CHANGELOG.md](https://github.com/google/google-id-token) |
-| `terraform-module` | [A terraform module, with a version in the README.md, and a CHANGELOG.md](https://github.com/terraform-google-modules/terraform-google-project-factory) |
-| rust              | A Rust repository, with a Cargo.toml (either as a crate or workspace) and a CHANGELOG.md |
-| ocaml             | [An OCaml repository, containing 1 or more opam or esy files and a CHANGELOG.md](https://github.com/grain-lang/binaryen.ml) |
-| go | Go repository, with a CHANGELOG.md |
+| `rust` | A Rust repository, with a Cargo.toml (either as a crate or workspace) and a CHANGELOG.md |
 | `simple` | [A repository with a version.txt and a CHANGELOG.md](https://github.com/googleapis/gapic-generator) |
-| helm | A helm chart repository with a Chart.yaml and a CHANGELOG.md |
-| elixir | An elixir repository with a mix.exs and a CHANGELOG.md |
+| `terraform-module` | [A terraform module, with a version in the README.md, and a CHANGELOG.md](https://github.com/terraform-google-modules/terraform-google-project-factory) |
 
 ## How release please works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.6.0",
-        "release-please": "^13.6.0"
+        "release-please": "^13.10.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.27.0",
@@ -4444,9 +4444,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.6.0.tgz",
-      "integrity": "sha512-dp01U7rYdt/d9i5E4TLinUbtAHcmZ6qYirvFG/KHD4FiNiPuhs57YrN1KwfhnM55YiNVIYj6U/OwSG/sYgXlww==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.10.0.tgz",
+      "integrity": "sha512-cH1oGvgS/Kryq2YmuEYnRLalT9VMQdCVix9nf++G+lPARWJiMVTowAfr5+m6+w7ApJn09oW9zWZ9Wv+N2M6hyg==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",
@@ -9102,9 +9102,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.6.0.tgz",
-      "integrity": "sha512-dp01U7rYdt/d9i5E4TLinUbtAHcmZ6qYirvFG/KHD4FiNiPuhs57YrN1KwfhnM55YiNVIYj6U/OwSG/sYgXlww==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.10.0.tgz",
+      "integrity": "sha512-cH1oGvgS/Kryq2YmuEYnRLalT9VMQdCVix9nf++G+lPARWJiMVTowAfr5+m6+w7ApJn09oW9zWZ9Wv+N2M6hyg==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bcoe/release-please-action#readme",
   "dependencies": {
     "@actions/core": "^1.6.0",
-    "release-please": "^13.6.0"
+    "release-please": "^13.10.0"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.27.0",


### PR DESCRIPTION
Updating release-please to get the new features available to the github action:

* **rust:** update Cargo.lock for single Rust crate ([#1374](https://github.com/googleapis/release-please/issues/1374)) ([e3571d3](https://github.com/googleapis/release-please/commit/e3571d32c44ae2bef8bac7dd8cdc3556a9d621c7))
* added java strategy ([#1333](https://github.com/googleapis/release-please/issues/1333)) ([25f9c85](https://github.com/googleapis/release-please/commit/25f9c85a8472208a83dfd5cc4014c84adc3c771f))
* Restore v12 changelog formatting for ruby-yoshi ([#1361](https://github.com/googleapis/release-please/issues/1361)) ([ff87c7d](https://github.com/googleapis/release-please/commit/ff87c7df00b652512641454ead34bb2cede2f67e))
* add dotnet-yoshi strategy ([#1346](https://github.com/googleapis/release-please/issues/1346)) ([3086e51](https://github.com/googleapis/release-please/commit/3086e5148e596751a2c2b82c28a7b3d3c1b960f2))

As part of the changes, I also sorted the language list and added `java` and `maven`.