### PR TITLE
chore: enable dependabot for updating release-please

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     commit-message:
-      prefix: "fix(deps): "
+      prefix: "fix"
     rebase-strategy: "auto"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    commit-message:
+      prefix: "fix(deps): "
+    rebase-strategy: "auto"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "release-please"


### PR DESCRIPTION
This should help us keep the action up to date with the underlying release-please library