### PR TITLE
feat: allow configure changelog-host

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Automate releases with Conventional Commit Messages.
 | `default-branch`  | branch to open pull release PR against (detected by default) |
 | `pull-request-title-pattern`  | title pattern used to make release PR, defaults to using `chore${scope}: release${component} ${version}`. |
 | `changelog-path` | configure alternate path for `CHANGELOG.md`. Default `CHANGELOG.md` |
+| `changelog-host` | configure alternate GitHub host for hyperlinks in changelog. Default `https://github.com` |
 | `github-api-url` | configure github API URL. Default `https://api.github.com` |
 | `--signoff` | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line at the end of the commit log message using the user and email provided. (format "Name \<email@example.com\>") |
 | `repo-url` | configure github repository URL. Default `process.env.GITHUB_REPOSITORY` |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Automate releases with Conventional Commit Messages.
 | `default-branch`  | branch to open pull release PR against (detected by default) |
 | `pull-request-title-pattern`  | title pattern used to make release PR, defaults to using `chore${scope}: release${component} ${version}`. |
 | `changelog-path` | configure alternate path for `CHANGELOG.md`. Default `CHANGELOG.md` |
-| `changelog-host` | configure alternate GitHub host for hyperlinks in changelog. Default `https://github.com` |
+| `changelog-host` | configure alternate GitHub host for hyperlinks in changelog |
 | `github-api-url` | configure github API URL. Default `https://api.github.com` |
 | `--signoff` | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line at the end of the commit log message using the user and email provided. (format "Name \<email@example.com\>") |
 | `repo-url` | configure github repository URL. Default `process.env.GITHUB_REPOSITORY` |

--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,9 @@ inputs:
     description: 'mark pull request as a draft'
     required: false
     default: false
+  changelog-host:
+    description: 'GitHub host for hyperlinks in changelog'
+    required: false
 
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -114,6 +114,7 @@ async function manifestInstance (github) {
   const releaseType = core.getInput('release-type', { required: true })
   const changelogPath = core.getInput('changelog-path') || undefined
   const changelogTypes = core.getInput('changelog-types') || undefined
+  const changelogHost = core.getInput('changelog-host') || undefined
   const changelogSections = changelogTypes && JSON.parse(changelogTypes)
   const versionFile = core.getInput('version-file') || undefined
   const extraFiles = core.getMultilineInput('extra-files') || undefined
@@ -130,6 +131,7 @@ async function manifestInstance (github) {
       releaseType,
       changelogPath,
       changelogSections,
+      changelogHost,
       versionFile,
       extraFiles,
       includeComponentInTag: monorepoTags,


### PR DESCRIPTION
# Purpose

- allow action to specify `changelog-host` so GitHub Enterprise can have correct hyperlinks in changelog(supported in v13.15.0)

- release-please 13.15.0: https://github.com/googleapis/release-please/releases/tag/v13.15.0
