### PR TITLE
fix: make `outputs.pr` returns only the PR number instead of an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,8 +185,8 @@ function outputReleases (releases) {
 function outputPRs (prs) {
   prs = prs.filter(pr => pr !== undefined)
   if (prs.length) {
-    core.setOutput('pr', prs[0])
-    core.setOutput('prs', JSON.stringify(prs))
+    core.setOutput('pr', prs[0].number)
+    core.setOutput('prs', JSON.stringify(prs.map((pr) => pr.number)))
   }
 }
 

--- a/test/release-please.js
+++ b/test/release-please.js
@@ -76,7 +76,7 @@ describe('release-please-action', () => {
         '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
     }
 
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake
     })
@@ -104,7 +104,7 @@ describe('release-please-action', () => {
       'pull-request-title-pattern': 'beep boop'
     }
 
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake
     })
@@ -132,7 +132,7 @@ describe('release-please-action', () => {
         tagName: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -164,7 +164,7 @@ describe('release-please-action', () => {
         tag_name: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -202,7 +202,7 @@ describe('release-please-action', () => {
         tag_name: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -229,7 +229,7 @@ describe('release-please-action', () => {
         tag_name: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -290,7 +290,7 @@ describe('release-please-action', () => {
       'release-type': 'node',
       command: 'release-pr'
     }
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake
     })
@@ -340,7 +340,7 @@ describe('release-please-action', () => {
         tag_name: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromManifest').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -369,7 +369,7 @@ describe('release-please-action', () => {
 
   it('opens PR only for manifest-pr', async () => {
     input = { command: 'manifest-pr' }
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromManifest').returns({
       createPullRequests: createPullRequestsFake
     })
@@ -403,7 +403,7 @@ describe('release-please-action', () => {
         path: 'b'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22, 33])
+    const createPullRequestsFake = sandbox.fake.returns([{ number: 22 }, { number: 33 }])
     const createManifestCommand = sandbox.stub(Manifest, 'fromManifest').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

## Why

fixes #438 

## What

- make `outputs.pr` returns the PR number instead of an object
- make `outputs.prs` returns the PR numbers array instead of an object
- fix tests
