### PR TITLE
test: fix `createPullRequestsFake()` returns wrong values

### DIFF
--- a/test/release-please.js
+++ b/test/release-please.js
@@ -25,6 +25,27 @@ const defaultInput = {
   'draft-pull-request': 'false'
 }
 
+const fixturePrs = [
+  {
+    headBranchName: 'release-please--branches--main',
+    baseBranchName: 'main',
+    number: 22,
+    title: 'chore(master): release 1.0.0',
+    body: ':robot: I have created a release *beep* *boop*',
+    labels: ['autorelease: pending'],
+    files: []
+  },
+  {
+    headBranchName: 'release-please--branches--main',
+    baseBranchName: 'main',
+    number: 23,
+    title: 'chore(master): release 1.0.0',
+    body: ':robot: I have created a release *beep* *boop*',
+    labels: ['autorelease: pending'],
+    files: []
+  }
+]
+
 let input
 let output
 
@@ -55,7 +76,7 @@ describe('release-please-action', () => {
       if (trueValue.includes(val)) { return true }
       if (falseValue.includes(val)) { return false }
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}\n` +
-          'Support boolean input list: `true | True | TRUE | false | False | FALSE`')
+        'Support boolean input list: `true | True | TRUE | false | False | FALSE`')
     }
     // Default branch lookup:
     nock('https://api.github.com')
@@ -76,7 +97,7 @@ describe('release-please-action', () => {
         '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
     }
 
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake
     })
@@ -104,7 +125,7 @@ describe('release-please-action', () => {
       'pull-request-title-pattern': 'beep boop'
     }
 
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake
     })
@@ -132,7 +153,7 @@ describe('release-please-action', () => {
         tagName: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -142,15 +163,16 @@ describe('release-please-action', () => {
     sinon.assert.calledTwice(createManifestCommand)
     sinon.assert.calledOnce(createPullRequestsFake)
     sinon.assert.calledOnce(createReleasesFake)
-    assert.deepStrictEqual(output, {
+    const { prs, ...outputWithoutPrs } = output
+    assert.deepStrictEqual(outputWithoutPrs, {
       release_created: true,
       upload_url: 'http://example.com',
       tag_name: 'v1.0.0',
-      pr: 22,
-      prs: '[22]',
+      pr: fixturePrs[0],
       releases_created: true,
       paths_released: '["."]'
     })
+    assert.deepStrictEqual(JSON.parse(prs), [fixturePrs[0]])
   })
 
   it('both opens PR to a different default branch and tags GitHub releases by default', async () => {
@@ -164,7 +186,7 @@ describe('release-please-action', () => {
         tag_name: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -180,15 +202,16 @@ describe('release-please-action', () => {
       sinon.match.any,
       sinon.match.any
     )
-    assert.deepStrictEqual(output, {
+    const { prs, ...outputWithoutPrs } = output
+    assert.deepStrictEqual(outputWithoutPrs, {
       release_created: true,
       upload_url: 'http://example.com',
       tag_name: 'v1.0.0',
-      pr: 22,
-      prs: '[22]',
+      pr: fixturePrs[0],
       releases_created: true,
       paths_released: '["."]'
     })
+    assert.deepStrictEqual(JSON.parse(prs), [fixturePrs[0]])
   })
 
   it('only opens PR, if command set to release-pr', async () => {
@@ -202,7 +225,7 @@ describe('release-please-action', () => {
         tag_name: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -212,10 +235,11 @@ describe('release-please-action', () => {
     sinon.assert.calledOnce(createManifestCommand)
     sinon.assert.calledOnce(createPullRequestsFake)
     sinon.assert.notCalled(createReleasesFake)
-    assert.deepStrictEqual(output, {
-      pr: 22,
-      prs: '[22]'
+    const { prs, ...outputWithoutPrs } = output
+    assert.deepStrictEqual(outputWithoutPrs, {
+      pr: fixturePrs[0]
     })
+    assert.deepStrictEqual(JSON.parse(prs), [fixturePrs[0]])
   })
 
   it('only creates GitHub release, if command set to github-release', async () => {
@@ -229,7 +253,7 @@ describe('release-please-action', () => {
         tag_name: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -290,7 +314,7 @@ describe('release-please-action', () => {
       'release-type': 'node',
       command: 'release-pr'
     }
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromConfig').returns({
       createPullRequests: createPullRequestsFake
     })
@@ -298,10 +322,11 @@ describe('release-please-action', () => {
 
     sinon.assert.calledOnce(createManifestCommand)
     sinon.assert.calledOnce(createPullRequestsFake)
-    assert.deepStrictEqual(output, {
-      pr: 22,
-      prs: '[22]'
+    const { prs, ...outputWithoutPrs } = output
+    assert.deepStrictEqual(outputWithoutPrs, {
+      pr: fixturePrs[0]
     })
+    assert.deepStrictEqual(JSON.parse(prs), [fixturePrs[0]])
   })
 
   it('does not set PR output, when no release PR is returned', async () => {
@@ -340,7 +365,7 @@ describe('release-please-action', () => {
         tag_name: 'v1.0.0'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromManifest').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -356,20 +381,21 @@ describe('release-please-action', () => {
       sinon.match.any,
       sinon.match.any
     )
-    assert.deepStrictEqual(output, {
+    const { prs, ...outputWithoutPrs } = output
+    assert.deepStrictEqual(outputWithoutPrs, {
       release_created: true,
       upload_url: 'http://example.com',
       tag_name: 'v1.0.0',
-      pr: 22,
-      prs: '[22]',
+      pr: fixturePrs[0],
       releases_created: true,
       paths_released: '["."]'
     })
+    assert.deepStrictEqual(JSON.parse(prs), [fixturePrs[0]])
   })
 
   it('opens PR only for manifest-pr', async () => {
     input = { command: 'manifest-pr' }
-    const createPullRequestsFake = sandbox.fake.returns([22])
+    const createPullRequestsFake = sandbox.fake.returns([fixturePrs[0]])
     const createManifestCommand = sandbox.stub(Manifest, 'fromManifest').returns({
       createPullRequests: createPullRequestsFake
     })
@@ -383,10 +409,11 @@ describe('release-please-action', () => {
       sinon.match.any,
       sinon.match.any
     )
-    assert.deepStrictEqual(output, {
-      pr: 22,
-      prs: '[22]'
+    const { prs, ...outputWithoutPrs } = output
+    assert.deepStrictEqual(outputWithoutPrs, {
+      pr: fixturePrs[0]
     })
+    assert.deepStrictEqual(JSON.parse(prs), [fixturePrs[0]])
   })
 
   it('sets appropriate output if multiple releases and prs created', async () => {
@@ -403,7 +430,7 @@ describe('release-please-action', () => {
         path: 'b'
       }
     ])
-    const createPullRequestsFake = sandbox.fake.returns([22, 33])
+    const createPullRequestsFake = sandbox.fake.returns(fixturePrs)
     const createManifestCommand = sandbox.stub(Manifest, 'fromManifest').returns({
       createPullRequests: createPullRequestsFake,
       createReleases: createReleasesFake
@@ -419,9 +446,9 @@ describe('release-please-action', () => {
       sinon.match.any,
       sinon.match.any
     )
-    assert.deepStrictEqual(output, {
-      pr: 22,
-      prs: '[22,33]',
+    const { prs, ...outputWithoutPrs } = output
+    assert.deepStrictEqual(outputWithoutPrs, {
+      pr: fixturePrs[0],
       releases_created: true,
       'a--release_created': true,
       'a--upload_url': 'http://example.com',
@@ -433,5 +460,6 @@ describe('release-please-action', () => {
       'b--path': 'b',
       paths_released: '["a","b"]'
     })
+    assert.deepStrictEqual(JSON.parse(prs), fixturePrs)
   })
 })


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

## Why

Related to #438 

Since release-please@13.0.0, [`createPullRequests()`](https://github.com/mshrtsr/release-please/blob/main/src/manifest.ts#L747) returns the array of the [PullRequest object](https://github.com/googleapis/release-please/blob/main/src/pull-request.ts#L15) instead of number.
This is applied in release-please-actions@3.0.0.

However, the return value of the mock function `createPullRequestsFake()` has not been updated. 

## What

- make `createPullRequestsFake()` returns the fixture PullRequest objects.
