### PR TITLE
fix: stop providing default values in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,19 +87,15 @@ inputs:
   monorepo-tags:
     description: 'add prefix to tags and branches, allowing multiple libraries to be released from the same repository'
     required: false
-    default: false
   pull-request-title-pattern:
     description: 'add title pattern to make release PR, defaults to using "chore${scope}: release${component} ${version}"'
     required: false
-    default: ''
   draft:
     description: 'mark release as a draft'
     required: false
-    default: false
   draft-pull-request:
     description: 'mark pull request as a draft'
     required: false
-    default: false
   changelog-notes-type:
     description: "Strategy for building the changelog contents(see https://github.com/googleapis/release-please/blob/main/docs/customizing.md#changelog-types). Default `default`. Called `changelog-type` in release-please documentation."
     required: false
@@ -112,18 +108,15 @@ inputs:
   skip-github-release:
     description: 'Skip creating GitHub Releases. Default `false`'
     required: false
-    default: false
   prerelease:
     description: 'If set, create releases that are pre-major or pre-release version marked as pre-release on Github. Defaults `false`'
     required: false
-    default: false
   component:
     description: 'name of the component used for branch naming and release tagging, defaults to a normalized version based on the package name'
     required: false
   include-v-in-tag:
     description: 'include "v" in tag versions. Default `true`'
     required: false
-    default: true
   tag-separator:
     description: 'configures separator character used in release tag'
     required: false
@@ -139,11 +132,9 @@ inputs:
   always-link-local:
     description: 'when using the `node-workspace` plugin, setting to false will only bump your local dependencies within the SemVer range (see the manifest releaser docs)[https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md) . Default `true`.'
     required: false
-    default: true
   separate-pull-requests:
     description: 'create separate pull requests for each package instead of a single manifest release pull request (see the manifest releaser docs https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md). Default `false`.'
     required: false
-    default: false
   plugins:
     description: 'see https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#plugins'
     required: false
@@ -156,11 +147,9 @@ inputs:
   skip-labeling:
     description: 'if set, labels will not be applied to pull requests. Default `false`.'
     required: false
-    default: false
   sequential-calls:
     description: 'issue GitHub API requests sequentially rather than concurrently (see the manifest releaser docs https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md). Default `false`'
     required: false
-    default: false
   group-pull-request-title-pattern:
     description: 'sets the manifest pull request title for when releasing multiple packages grouped together in the one pull request'
     required: false

--- a/index.js
+++ b/index.js
@@ -14,13 +14,27 @@ const signoff = core.getInput('signoff') || undefined
 
 function getGitHubInput () {
   return {
-    fork: core.getBooleanInput('fork'),
+    fork: getOptionalBooleanInput('fork'),
     defaultBranch: core.getInput('default-branch') || undefined,
     repoUrl: core.getInput('repo-url') || process.env.GITHUB_REPOSITORY,
     apiUrl: core.getInput('github-api-url') || GITHUB_API_URL,
     graphqlUrl: (core.getInput('github-graphql-url') || '').replace(/\/graphql$/, '') || GITHUB_GRAPHQL_URL,
     token: core.getInput('token', { required: true })
   }
+}
+
+function getOptionalBooleanInput (name) {
+  if (core.getInput(name) === '') {
+    return undefined
+  }
+  return core.getBooleanInput(name)
+}
+
+function getOptionalMultilineInput (name) {
+  if (core.getInput(name) === '') {
+    return undefined
+  }
+  return core.getMultilineInput(name)
 }
 
 function getManifestInput () {
@@ -106,9 +120,9 @@ function getGitHubInstance () {
 
 async function manifestInstance (github) {
   const { fork } = getGitHubInput()
-  const bumpMinorPreMajor = core.getBooleanInput('bump-minor-pre-major')
-  const bumpPatchForMinorPreMajor = core.getBooleanInput('bump-patch-for-minor-pre-major')
-  const monorepoTags = core.getBooleanInput('monorepo-tags')
+  const bumpMinorPreMajor = getOptionalBooleanInput('bump-minor-pre-major')
+  const bumpPatchForMinorPreMajor = getOptionalBooleanInput('bump-patch-for-minor-pre-major')
+  const monorepoTags = getOptionalBooleanInput('monorepo-tags')
   const packageName = core.getInput('package-name') || undefined
   const path = core.getInput('path') || undefined
   const releaseType = core.getInput('release-type', { required: true })
@@ -119,26 +133,26 @@ async function manifestInstance (github) {
   const versionFile = core.getInput('version-file') || undefined
   const extraFiles = core.getMultilineInput('extra-files') || undefined
   const pullRequestTitlePattern = core.getInput('pull-request-title-pattern') || undefined
-  const draft = core.getBooleanInput('draft')
-  const draftPullRequest = core.getBooleanInput('draft-pull-request')
+  const draft = getOptionalBooleanInput('draft')
+  const draftPullRequest = getOptionalBooleanInput('draft-pull-request')
   const changelogType = core.getInput('changelog-notes-type') || undefined
   const versioning = core.getInput('versioning-strategy') || undefined
   const releaseAs = core.getInput('release-as') || undefined
-  const skipGithubRelease = core.getBooleanInput('skip-github-release')
-  const prerelease = core.getBooleanInput('prerelease')
+  const skipGithubRelease = getOptionalBooleanInput('skip-github-release')
+  const prerelease = getOptionalBooleanInput('prerelease')
   const component = core.getInput('component') || undefined
-  const includeVInTag = core.getBooleanInput('include-v-in-tag')
+  const includeVInTag = getOptionalBooleanInput('include-v-in-tag')
   const tagSeparator = core.getInput('tag-separator') || undefined
-  const snapshotLabels = core.getInput('snapshot-labels') ? core.getMultilineInput('snapshot-labels') : undefined
+  const snapshotLabels = getOptionalMultilineInput('snapshot-labels')
   const bootstrapSha = core.getInput('bootstrap-sha') || undefined
   const lastReleaseSha = core.getInput('last-release-sha') || undefined
-  const alwaysLinkLocal = core.getBooleanInput('always-link-local')
-  const separatePullRequests = core.getBooleanInput('separate-pull-requests')
+  const alwaysLinkLocal = getOptionalBooleanInput('always-link-local')
+  const separatePullRequests = getOptionalBooleanInput('separate-pull-requests')
   const plugins = core.getMultilineInput('plugins') || undefined
   const labels = core.getInput('labels') ? core.getMultilineInput('labels') : undefined
-  const releaseLabels = core.getInput('release-labels') ? core.getMultilineInput('release-labels') : undefined
-  const skipLabeling = core.getBooleanInput('skip-labeling')
-  const sequentialCalls = core.getBooleanInput('sequential-calls')
+  const releaseLabels = getOptionalMultilineInput('release-labels')
+  const skipLabeling = getOptionalBooleanInput('skip-labeling')
+  const sequentialCalls = getOptionalBooleanInput('sequential-calls')
   const groupPullRequestTitlePattern = core.getInput('group-pull-request-title-pattern') || undefined
   const releaseSearchDepth = core.getInput('release-search-depth') || undefined
   const commitSearchDepth = core.getInput('commit-search-depth') || undefined


### PR DESCRIPTION
`monorepo-tags` default is actually conditional based on the number of components in the repo

Test ran this branch and it opened https://github.com/google-github-actions/release-please-action/pull/575 which is correct (not https://github.com/google-github-actions/release-please-action/pull/568)