### PR TITLE
Revert "chore: release main"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## [3.4.0](https://github.com/google-github-actions/release-please-action/compare/v3.3.0...v3.4.0) (2022-08-16)
-
-
-### Features
-
-* provide inputs for releaser and manifest options in release-please 13.15 ([#474](https://github.com/google-github-actions/release-please-action/issues/474)) ([4482754](https://github.com/google-github-actions/release-please-action/commit/44827541d2a562fef8aedc1379c814c04f0ad482))
-* read github api/graphql url from action context ([#532](https://github.com/google-github-actions/release-please-action/issues/532)) ([922ac8b](https://github.com/google-github-actions/release-please-action/commit/922ac8b6dbe224c50b1b79387e74a6def9cd63c7))
-
-
-### Bug Fixes
-
-* bump release-please from 13.20.0 to 13.21.0 ([#559](https://github.com/google-github-actions/release-please-action/issues/559)) ([bab175e](https://github.com/google-github-actions/release-please-action/commit/bab175efb54ba5015c7b864d92ade6415319d9ec))
-* default labels should be undefined ([#566](https://github.com/google-github-actions/release-please-action/issues/566)) ([0647714](https://github.com/google-github-actions/release-please-action/commit/06477146cda1700a641367412e0993a768b76b65))
-
 ## [3.3.0](https://github.com/google-github-actions/release-please-action/compare/v3.2.10...v3.3.0) (2022-08-10)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "release-please-action",
-  "version": "3.4.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "release-please-action",
-      "version": "3.4.0",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "release-please-action",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.0",
   "description": "automated releases based on conventional commits",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Reverts google-github-actions/release-please-action#568

This was a bad build because monorepo-tags input's default is actually conditional