### PR TITLE
feat: read changelog-host url from action context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
   changelog-host:
     description: 'The proto://host where commits live.'
     required: false
-    default: 'https://github.com'
+    default: ${{ github.server_url }}
   command:
     description: 'release-please command to run, either "github-release", or "release-pr" (defaults to running both)'
     required: false


### PR DESCRIPTION
Similar to #532, Fix #508

This allowed GitHub Enterprise users to use this action without specifying `changelog-host` to GitHub Enterprise Server URL

(related: #525, #550)