### PR TITLE
feat: allow workflows on github enterprise not to to specify changelog-host

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
   changelog-host:
     description: 'The proto://host where commits live.'
     required: false
-    default: 'https://github.com'
+    default: ${{ github.server_url }}
   command:
     description: 'release-please command to run, either "github-release", or "release-pr" (defaults to running both)'
     required: false


### PR DESCRIPTION
Fix #588 