### PR TITLE
feat: run action on node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -162,5 +162,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
release-please v14 requires node14+. GitHub actions does not support node14, so we jump to node16.