### PR TITLE
docs: Fix typo in action outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Release Please automates releases for the following flavors of repositories:
 
 | output | description |
 |:---:|---|
-| `release_created` | `true` if the release was created, `false` otherwise |
+| `releases_created` | `true` if the release was created, `false` otherwise |
 | `upload_url` | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `html_url` | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `tag_name` | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |


### PR DESCRIPTION
### This PR
- fixes a typo in the action outputs in README.md
- the code [here](https://github.com/google-github-actions/release-please-action/blob/main/index.js#L214) shows that the output variable is actually called `releases_created` instead of `release_created`

