### PR TITLE
Update branch to use node16.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,5 +58,5 @@ inputs:
     default: 'chore${scope}: release${component} ${version}'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Currently we have additional release strategy logic in this branch and it uses node12 which is deprecated by github. Updating to node16. Long term we need to somehow implement the release strategy in this branch in main. 

Signed-off-by: jeremytchang <78522362+jeremytchang@users.noreply.github.com>

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
