### PR TITLE
docs: add `sfdx` supported release type

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Release Please automates releases for the following flavors of repositories:
 | `php` | [A php composer package with composer.json and CHANGELOG.md](https://github.com/setnemo/asterisk-notation)
 | `ruby` | [A Ruby repository, with version.rb and CHANGELOG.md](https://github.com/google/google-id-token) |
 | `rust` | A Rust repository, with a Cargo.toml (either as a crate or workspace) and a CHANGELOG.md |
+| `sfdx` | A repository with a [sfdx-project.json](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_config.htm) and a CHANGELOG.md |
 | `simple` | [A repository with a version.txt and a CHANGELOG.md](https://github.com/googleapis/gapic-generator) |
 | `terraform-module` | [A terraform module, with a version in the README.md, and a CHANGELOG.md](https://github.com/terraform-google-modules/terraform-google-project-factory) |
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

List `sfdx` as a supported release type
`sfdx` release type is included since release please [v15.9.0](https://github.com/googleapis/release-please/releases/tag/v15.9.0), which is used in the github action since [v3.7.6](https://github.com/google-github-actions/release-please-action/releases/tag/v3.7.6).