### PR TITLE
docs: Clarify `package-name` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Automate releases with Conventional Commit Messages.
           - uses: google-github-actions/release-please-action@v3
             with:
               release-type: node
-              package-name: release-please-action
+              package-name: <your-package-name>
     ```
 
 3. Merge the above action into your repository and make sure new commits follow


### PR DESCRIPTION
Hey, perhaps I'm missing something, but as far as I understand it's not correct to use `package-name: release-please-action` verbatim – the name of the actual package in question should be used instead. This is not how I read the example workflow the README suggests to copy, so I hope this is an improvement.