### PR TITLE
Make release-type not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   release-type:
     description: 'what type of release is this, one of (ruby, python, node, terraform-module)'
-    required: true
+    required: false
   bump-minor-pre-major:
     description: 'should breaking changes before 1.0.0 produce minor bumps'
     required: false


### PR DESCRIPTION
- [x] Switch the `release-type` requirement to `false`. 
- [x] If the release type is not provided, it will default to the config found in `release-please-config.json` 



Fixes: 
https://github.com/google-github-actions/release-please-action/issues/828
https://github.com/google-github-actions/release-please-action/issues/831