### PR TITLE
ci: add action to try to build the dist file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,16 @@ jobs:
           node-version: 20
       - run: npm install
       - run: npm test
+  build-dist:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm run build
+


### PR DESCRIPTION
Tries to compile the single .js file. If the command fails, then the test is marked as a failure.