### PR TITLE
fix: restore include-component-in-tag default (false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ steps:
 | `github-api-url`           | Override the GitHub API URL.                                                                                                           |
 | `github-graphql-url`       | Override the GitHub GraphQL URL                                                                                                        |
 | `fork`                     | If `true`, send the PR from a fork. This requires the `token` to be a user that can create forks (e.g. not the default `GITHUB_TOKEN`) |
+| `include-component-in-tag` | If true, add prefix to tags and branches, allowing multiple libraries to be released from the same repository                          |
 | `proxy-server`             | Configure a proxy servier in the form of `<host>:<port>` e.g. `proxy-host.com:8080`                                                    |
 | `skip-github-release`      | If `true`, do not attempt to create releases. This is useful if splitting release tagging from PR creation.                            |
 | `skip-github-pull-request` | If `true`, do not attempt to create release pull requests. This is useful if splitting release tagging from PR creation.               |

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ inputs:
     description: 'If true, send the PR from a fork. This requires the token to be a user that can create forks (e.g. not the default GITHUB_TOKEN)'
     required: false
     default: false
+  include-component-in-tag:
+    description: 'If true, add prefix to tags and branches, allowing multiple libraries to be released from the same repository'
+    required: false
   proxy-server:
     description: 'set proxy sever when you run this action behind a proxy. format is host:port e.g. proxy-host.com:8080'
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ interface ActionInputs {
   skipGitHubRelease?: boolean;
   skipGitHubPullRequest?: boolean;
   fork?: boolean;
+  includeComponentInTag?: boolean;
 }
 
 // TODO: replace this interface is exported from release-please
@@ -86,6 +87,7 @@ function parseInputs(): ActionInputs {
     skipGitHubRelease: getOptionalBooleanInput('skip-github-release'),
     skipGitHubPullRequest: getOptionalBooleanInput('skip-github-pull-request'),
     fork: getOptionalBooleanInput('fork'),
+    includeComponentInTag: getOptionalBooleanInput('include-component-in-tag'),
   };
   return inputs;
 }
@@ -113,6 +115,7 @@ function loadOrBuildManifest(
       github.repository.defaultBranch,
       {
         releaseType: inputs.releaseType,
+        includeComponentInTag: inputs.includeComponentInTag,
       },
       {
         fork: inputs.fork,


### PR DESCRIPTION
v3 had this option and must be configurable or at least set to `false` so that the default behavior is to create a plain `v1.2.3` tag (without the component name prefixed).

Found this while dogfooding our own usage of the action (in this repo).