### PR TITLE
build: the include-component-in-tag should default to false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,7 @@ inputs:
   include-component-in-tag:
     description: 'If true, add prefix to tags and branches, allowing multiple libraries to be released from the same repository'
     required: false
+    default: false
   proxy-server:
     description: 'set proxy sever when you run this action behind a proxy. format is host:port e.g. proxy-host.com:8080'
     required: false


### PR DESCRIPTION
The default should be to create plain tags like `v1.2.3`

