### PR TITLE
build: remove unneeded, failing labelling step

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -97,17 +97,3 @@ jobs:
           release-type: node
           fork: true
           skip-github-release: true
-      - id: label
-        if: ${{ steps.release-pr.outputs.pr }}
-        uses: actions/github-script@v3
-        with:
-            github-token: ${{secrets.GITHUB_TOKEN}}
-            script: |
-              const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-              await github.issues.addLabels({
-                owner,
-                repo,
-                issue_number: ${{steps.release-pr.outputs.pr}},
-                labels: ['autorelease: pending']
-              });
-              console.log(`Tagged ${{steps.release-pr.outputs.pr}}`)


### PR DESCRIPTION
release-please already adds the `autorelease:pending` label

It has been failing for quite awhile with:
```
SyntaxError: missing ) after argument list
    at new AsyncFunction (<anonymous>)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:7514:16)
Error: Unhandled error: SyntaxError: missing ) after argument list
    at main (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:7541:26)
    at Module.720 (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:7525:1)
    at __webpack_require__ (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:24:31)
    at startup (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:43:[19](https://github.com/google-github-actions/release-please-action/actions/runs/7064411294/job/19232404141#step:3:20))
    at /home/runner/work/_actions/actions/github-script/v3/dist/index.js:49:18
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:52:10)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1[25](https://github.com/google-github-actions/release-please-action/actions/runs/7064411294/job/19232404141#step:3:26)2:10)
```
