### PR TITLE
docs: update to `target-branch` option for non-default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The most important prefixes you should have in mind are:
 ### Supporting multiple release branches
 
 `release-please` has the ability to target not default branches. You can even use separate release strategies (`release-type`).
-To configure, simply configure multiple workflows that specify a different `default-branch`:
+To configure, simply configure multiple workflows that specify a different `target-branch`:
 
 Configuration for `main` (default) branch (`.github/workflows/release-main.yaml`):
 
@@ -252,7 +252,7 @@ jobs:
           release-type: node
           # The short ref name of the branch or tag that triggered
           #  the workflow run. For example, `main` or `1.x`
-          default-branch: ${{ github.ref_name }}
+          target-branch: ${{ github.ref_name }}
 ```
 
 ## Automating publication to npm


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
This PR updates the docs to switch usages to `target-branch` as this has changed in v4.