### PR TITLE
feat: add `changelog-host` input to `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: 'if set to true, then do not try to open pull requests'
     required: false
     default: false
+  changelog-host:
+    description: 'The proto://host where commits live. Default `https://github.com`'
+    required: false
+    default: ${{ github.server_url }}
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ const DEFAULT_CONFIG_FILE = 'release-please-config.json';
 const DEFAULT_MANIFEST_FILE = '.release-please-manifest.json';
 const DEFAULT_GITHUB_API_URL = 'https://api.github.com';
 const DEFAULT_GITHUB_GRAPHQL_URL = 'https://api.github.com';
+const DEFAULT_GITHUB_SERVER_URL = 'https://github.com';
 
 interface Proxy {
   host: string;
@@ -40,6 +41,7 @@ interface ActionInputs {
   skipGitHubPullRequest?: boolean;
   fork?: boolean;
   includeComponentInTag?: boolean;
+  changelogHost: string;
 }
 
 function parseInputs(): ActionInputs {
@@ -60,6 +62,7 @@ function parseInputs(): ActionInputs {
     skipGitHubPullRequest: getOptionalBooleanInput('skip-github-pull-request'),
     fork: getOptionalBooleanInput('fork'),
     includeComponentInTag: getOptionalBooleanInput('include-component-in-tag'),
+    changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
   };
   return inputs;
 }
@@ -88,6 +91,7 @@ function loadOrBuildManifest(
       {
         releaseType: inputs.releaseType,
         includeComponentInTag: inputs.includeComponentInTag,
+        changelogHost: inputs.changelogHost,
       },
       {
         fork: inputs.fork,


### PR DESCRIPTION
This was originally part of [3.3.0](https://github.com/google-github-actions/release-please-action/blob/main/CHANGELOG.md#330-2022-08-10) (and fixed in [3.4.1](https://github.com/google-github-actions/release-please-action/blob/main/CHANGELOG.md#341-2022-08-24) to default to `github.server_url`). However, it was not part of 4.0.0.

Without this input, you have to provide both config and manifest files in order to set the `changelog-host` option. 

With this input, you can simply provide `release-type` and `changelog-host` without the need for config and manifest files. Also, since it defaults to `github.server_url`, most users will not even have to set it.